### PR TITLE
Add 5000ms timeout to feed fetch

### DIFF
--- a/src/reddit-service.ts
+++ b/src/reddit-service.ts
@@ -14,7 +14,8 @@ export interface RedditPost {
 const parser = new Parser({
   customFields: {
     item: ['author', 'id']
-  }
+  },
+  timeout: 5000,
 });
 
 /**


### PR DESCRIPTION
The default timeout is 1 minute -- probably not necessary to wait that long, so let's try a tighter timeout and let it retry.
